### PR TITLE
Add support for ICU message format

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,24 @@ For full list of features see [Wikipedia](http://en.wikipedia.org/wiki/YAML#Exam
 **Note:**
 Although YAML supports data types, the module ignores them to preserve the compatibility with the MessagingAPI. 
 
+**Support for ICU message format**
+
+You can switch between the default JDK MessageFormat implementation and the implementation provided by the [ICU Project](http://icu-project.org).
+
+To enable ICU's implementation just set the configuration option `play.i18n.useICUMessageFormat` to `true`.
+
+See `MultiFormatMessagingPluginSpec` for an example how to use the advanced formatting options of the ICU project.
+
 ## Configuration
 
 There is already default configuration but it can be overwritten in your `conf/application.conf` file.
 
-| Key                           | Type   | Default                       | Description                         |
-|-------------------------------|-------:|------------------------------:|-------------------------------------|
-| play.i18n.path                | String | empty                         | Prefix of messages files            |
-| play.i18n.formats.properties  | Boolean| true                          | Enables the format                  |
-| play.i18n.formats.yaml        | Boolean| true                          | Enables the format                  |
+| Key                           | Type   | Default                       | Description                                |
+|-------------------------------|-------:|------------------------------:|--------------------------------------------|
+| play.i18n.path                | String | empty                         | Prefix of messages files                   |
+| play.i18n.formats.properties  | Boolean| true                          | Enables the format                         |
+| play.i18n.formats.yaml        | Boolean| true                          | Enables the format                         |
+| play.i18n.useICUMessageFormat | Boolean| false                         | Enables the support for ICU message format |
 
 
 ## Worth knowing to avoid surprises

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % playVersion % "provided",
   // YAML parser, Java library
   "org.yaml" % "snakeyaml" % "1.19",
+  // ICU4J message format support
+  "com.ibm.icu" % "icu4j" % "62.1",
   // test framework
   "org.specs2" %% "specs2-core" % specs2Version % "test",
   // test module for play framework

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -10,6 +10,8 @@ play.i18n {
     yaml: true
   }
 
+  useICUMessageFormat: false
+
   # base names of files
   files: [ "messages" ]
 }

--- a/src/test/resources/messages
+++ b/src/test/resources/messages
@@ -1,2 +1,18 @@
 a.b.c = a={0} b={1} c={2}
 collision = Collision in file ''messages''
+p.icu = {gender,select,\
+   female {{num_guests,plural,offset:1 \
+     =0{{host} does not give a party.} \
+     =1{{host} invites {guest} to her party on {d,date,full}.} \
+     =2{{host} invites {guest} and one other person to her party on {d,date,full}.} \
+     other{{host} invites {guest} and # other people to her party on {d,date,full}.}}}\
+   male {{num_guests, plural, offset:1 \
+     =0 {{host} does not give a party.} \
+     =1 {{host} invites {guest} to his party on {d,date,full}.} \
+     =2 {{host} invites {guest} and one other person to his party on {d,date,full}.} \
+     other {{host} invites {guest} and # other people to his party on {d,date,full}.}}}\
+  other {{num_guests, plural, offset:1  \
+      =0 {{host} does not give a party.} \
+      =1 {{host} invites {guest} to their party on {d,date,full}.} \
+      =2 {{host} invites {guest} and one other person to their party on {d,date,full}.} \
+      other {{host} invites {guest} and # other people to their party on {d,date,full}.}}}}

--- a/src/test/resources/messages.yaml
+++ b/src/test/resources/messages.yaml
@@ -9,3 +9,21 @@ a:
   e: &idA
     a: An example
   g: *idA
+y:
+  icu: >
+       {gender, select,
+         female {{num_guests, plural, offset:1
+             =0 {{host} does not give a party.}
+             =1 {{host} invites {guest} to her party on {d,date,full}.}
+             =2 {{host} invites {guest} and one other person to her party on {d,date,full}.}
+             other {{host} invites {guest} and # other people to her party on {d,date,full}.}}}
+         male {{num_guests, plural, offset:1
+             =0 {{host} does not give a party.}
+             =1 {{host} invites {guest} to his party on {d,date,full}.}
+             =2 {{host} invites {guest} and one other person to his party on {d,date,full}.}
+             other {{host} invites {guest} and # other people to his party on {d,date,full}.}}}
+         other {{num_guests, plural, offset:1
+             =0 {{host} does not give a party.}
+             =1 {{host} invites {guest} to their party on {d,date,full}.}
+             =2 {{host} invites {guest} and one other person to their party on {d,date,full}.}
+             other {{host} invites {guest} and # other people to their party on {d,date,full}.}}}}

--- a/src/test/scala/play/ext/i18n/MultiFormatMessagingPluginSpec.scala
+++ b/src/test/scala/play/ext/i18n/MultiFormatMessagingPluginSpec.scala
@@ -57,5 +57,16 @@ class MultiFormatMessagingPluginSpec extends PlaySpecification {
       // warning log is expected
       true mustEqual true
     }
+
+    "properly parse ICU message format in property and YAML files" in {
+      val icuInjector = new GuiceApplicationBuilder().configure(Map("play.i18n.useICUMessageFormat" -> true)).build().injector
+      val icuMessages = icuInjector.instanceOf[MessagesApi]
+      val date = new java.util.Date(0)
+
+      icuMessages("p.icu", Map("gender" -> "female", "num_guests" -> 2, "host" -> "TheHost", "guest" -> "TheGuest", "d" -> date))(en) mustEqual "TheHost invites TheGuest and one other person to her party on Thursday, January 1, 1970."
+      icuMessages("p.icu", Map("gender" -> "male", "num_guests" -> 3, "host" -> "TheHost", "guest" -> "TheGuest", "d" -> date))(en) mustEqual "TheHost invites TheGuest and 2 other people to his party on Thursday, January 1, 1970."
+      icuMessages("y.icu", Map("gender" -> "female", "num_guests" -> 2, "host" -> "TheHost", "guest" -> "TheGuest", "d" -> date))(en) mustEqual "TheHost invites TheGuest and one other person to her party on Thursday, January 1, 1970."
+      icuMessages("y.icu", Map("gender" -> "male", "num_guests" -> 3, "host" -> "TheHost", "guest" -> "TheGuest", "d" -> date))(en) mustEqual "TheHost invites TheGuest and 2 other people to his party on Thursday, January 1, 1970."
+    }
   }
 }


### PR DESCRIPTION
The ICU project (http://icu-project.org) provides a richer MessageFormat implementation than the JDK's default implementation.

This PR adds support for the ICU implementation. Default configuration keeps ICU format disabled, i.e. the JDK's default MessageFormat implementation is used. ICU message format can be enabled by setting play.i18n.useICUMessageFormat to true.

Please see MultiFormatMessagingPluginSpec for an example how to use the ICU message format.