### PR TITLE
Play 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Multi-format Messaging module<br/> for Play framework</h1>
 
-**Note: This version supports Play framework 2.6.x. For compatiblity with previous versions see previous releases.**
+**Note: This version supports Play framework 2.7.x. For compatibility with previous versions see previous releases.**
 
 [Play framework 2](http://playframework.com/) is delivered with default Messaging module using property
 files. The syntax is not much convenient as involves a lot of repetition, thus this module delivers

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalaVersion := "2.12.8"
 
 crossScalaVersions := Seq( scalaVersion.value, "2.11.12" )
 
-val playVersion = "2.6.10"
+val playVersion = "2.7.0"
 
 val specs2Version = "4.4.1"
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,19 +8,19 @@ description := "Messaging localization plugin for the Play framework 2"
 
 organization := "com.github.karelcemus"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.8"
 
 crossScalaVersions := Seq( scalaVersion.value, "2.11.12" )
 
 val playVersion = "2.6.10"
 
-val specs2Version = "4.0.2"
+val specs2Version = "4.4.1"
 
 libraryDependencies ++= Seq(
   // play framework cache API
   "com.typesafe.play" %% "play" % playVersion % "provided",
   // YAML parser, Java library
-  "org.yaml" % "snakeyaml" % "1.19",
+  "org.yaml" % "snakeyaml" % "1.24",
   // test framework
   "org.specs2" %% "specs2-core" % specs2Version % "test",
   // test module for play framework

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 // library release
-addSbtPlugin( "com.github.gseitz" % "sbt-release" % "1.0.6" )
+addSbtPlugin( "com.github.gseitz" % "sbt-release" % "1.0.11" )
 
 // PGP signature
-addSbtPlugin( "com.jsuereth" % "sbt-pgp" % "1.1.0" )
+addSbtPlugin( "com.jsuereth" % "sbt-pgp" % "1.1.2" )
 
 // checks for updates
-addSbtPlugin( "com.timushev.sbt" % "sbt-updates" % "0.3.1" )
+addSbtPlugin( "com.timushev.sbt" % "sbt-updates" % "0.4.0" )


### PR DESCRIPTION
Fixes #16 

@dmitchellmim Would you mind to test this? I have upgraded the dependencies but encountered no error and tests pass. Therefore I suggest to test it and if it works, I'll release it.

To test it, use version `1.2.0-SNAPSHOT` and include sonatype snapshot repository among resolvers

```scala
resolvers += Opts.resolver.sonatypeSnapshots
```

If the issue persists, I'll trace it, however, it seems that it works.