### PR TITLE
Allow untrimmed whitespace according to YAML.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,42 @@
 language: scala
-jdk:
-- oraclejdk8
+dist: bionic
 scala:
-- 2.12.3
+- 2.13.1
 branches:
   only:
   - master
 cache:
   directories:
-  - $HOME/.ivy2/cache
+    - "$HOME/.ivy2/cache"
+    - "$HOME/.ivy2/local"
+    - "$HOME/.coursier"
+    - "$HOME/.jabba/jdk"
+    - "$HOME/.sbt"
+
 env:
   global:
   - secure: cKAh549EmVROXviynjVf9epC9SYx8zn4WOU/FAPlDxSah8VmXBrOmHaZmvK7vu5eaOjUj0urHFggQ+lkaRKHs1RSvusx35MO9LIJBt7Nemb+1j8nNddZAN4ck54tGc2JsazLWnfwDC/DCbqrXBrtZcCAkfQbtiJvipqVabXEyPdGIKTnF5RjDengfRW7qz78oGX/pqVp/AJbTzsLJoAWCPrMa6X48NM68ksw9bmoy2+L9/4FGtwyUApmDqj+Zph6OqCP6bU/AfCR3YDxHd5Ea5rwrszDrilsYDNrPIXyY1NeKgRVpvMxoe4cSONnr4f1ScW/WV3bzusFeMJPci7nvqpNCfjDB9nDDmcmL+PdYPEzuu03aUqMAp7T4Szg6m4q9WzXsZ17IhrE+uq9kAM6hxeDuNBeczkOEwsgfZpcDvHlN65XXGXpUvZX69mzXoFMkYeHISpr2Vw8gLKw3sF14KFg1JPO2uIHOLrM9FaDsvUCgmg/Er7rRZkEDQUXF8UT4JUt6P6OneYTMfnF9VorENCR7o1K1EyCjTHeOIZ3zh5jCLzBIpXeR4e/HY15dpwDArXErjmWoR2f+OpjkgUr4gOw/JODU4OfRRGn8ptJFq+fRw58eXHvp9D+GPvRaDKYKht4Y5sb6R96mCkxv7Cg5B1dzJLNsVBecVgMOZ2Hrk8=
   - secure: kHtHIFpZw8snrvs9SW4jl/wgd4YF2/DIJ0W9ueGdwzEWDcTnFK+8AVxYT0Ee5hfYDprna4lWKNClERWJKw5eSfCPQpoGbbULdz5f0b6/sVEAKmGCVAGPwkfkS0pRoOIaIT04rrK2I725VGx1JLo8JWSkLCWy/DmGzhBdp1tGONoFVsADlSvLSoG1zh+qey5p4kdFZT5O3t8tUo1OTQIoi3dXuIJVUuAML3a4BW/brM6LKizNxdMuytnWLSavEMAFggQHvodV+TIxVjXy8XXLPcpEi+KU6g5CPr+IVkW/xvjRsgQt933NaLZKMDJXCvhBiL5h8MuXg+rJnzsLPXPKzHwVFNquxBphm3fFNqBZReKb0fcgaOBG5wyRlasp6JqTPXH0j+pWNpXfpwg5OynKoDeJmgb4mmfK11HzNFuTL7YgIlU8OtDQPYR2xOvZ9LxBam1a9G0j1aJ98eERuJBBzR1bXlbidjKLZuJX7hKo9isqEuHdZKOefuDaH0QORiLJzsqt23Omy8cIN/QWu9Vsfq8zEMxsLPYRS2FRF7GfqGs5Xy0E0kqSIAoXKMb5i/CZ3ni7Hw3UapTkDx7SCVG/Oxybh6AwhAaZp/UjFOGcYIqyxmISz1d8Aad+qeCHv4GKl0q3MwGvCPNyirRVecs2TPsS0UA3SlcAW3MetrcxmtY=
+  - COURSIER_CACHE="$HOME/.coursier"
+  # set version of JDK
+  - TRAVIS_JDK=adopt@1.8.202-08
+  - SCALA_VERSION=2.13.1
+
+before_install:
+  - curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
+
+install:
+  - jabba install "$TRAVIS_JDK" && jabba use "$TRAVIS_JDK" && java -Xmx32m -version
+
 before_script:
+# test java version
+- ! 'javac -version'
 # define command on master
 - ! 'CMD_MA="+compile +test +publish"'
 # define command on pull request
 - ! 'CMD_PR="+test"'
 # publish on master, test otherwise
 - ! '[[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == false ]] && SBT_CMD="$CMD_MA" || SBT_CMD="$CMD_PR"'
+
 script:
 - sbt $SBT_CMD

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import com.typesafe.sbt.pgp.PgpKeys
+import com.jsuereth.sbtpgp.PgpKeys
 import sbt.Keys._
 import sbt._
 
@@ -8,19 +8,19 @@ description := "Messaging localization plugin for the Play framework 2"
 
 organization := "com.github.karelcemus"
 
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.1"
 
-crossScalaVersions := Seq( scalaVersion.value, "2.11.12" )
+crossScalaVersions := Seq( scalaVersion.value, "2.12.10", "2.11.12" )
 
-val playVersion = "2.7.0"
+val playVersion = "2.7.3"
 
-val specs2Version = "4.4.1"
+val specs2Version = "4.7.1"
 
 libraryDependencies ++= Seq(
   // play framework cache API
   "com.typesafe.play" %% "play" % playVersion % "provided",
   // YAML parser, Java library
-  "org.yaml" % "snakeyaml" % "1.24",
+  "org.yaml" % "snakeyaml" % "1.25",
   // test framework
   "org.specs2" %% "specs2-core" % specs2Version % "test",
   // test module for play framework
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-specs2" % playVersion % "test"
 )
 
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 javacOptions ++= Seq( "-source", "1.8", "-target", "1.8", "-Xlint:unchecked", "-encoding", "UTF-8" )
 
@@ -36,7 +36,7 @@ scalacOptions ++= Seq( "-deprecation", "-feature", "-unchecked", "-Yrangepos" )
 
 homepage := Some( url( "https://github.com/karelcemus/play-i18n" ) )
 
-licenses := Seq( "Apache 2" -> url( "http://www.apache.org/licenses/LICENSE-2.0" ) )
+licenses := Seq( "Apache 2" -> url( "https://www.apache.org/licenses/LICENSE-2.0" ) )
 
 publishMavenStyle := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 // library release
-addSbtPlugin( "com.github.gseitz" % "sbt-release" % "1.0.11" )
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 // PGP signature
-addSbtPlugin( "com.jsuereth" % "sbt-pgp" % "1.1.2" )
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
 
 // checks for updates
-addSbtPlugin( "com.timushev.sbt" % "sbt-updates" % "0.4.0" )
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.2")

--- a/src/main/scala/play/ext/i18n/loaders/YamlFileLoader.scala
+++ b/src/main/scala/play/ext/i18n/loaders/YamlFileLoader.scala
@@ -45,7 +45,7 @@ class YamlFileLoader extends MessagesLoader {
       case (suffix, value) => s"$prefix.$suffix" -> value
     }
     // leaf
-    case (key: String, value: String) => Map(key -> value.trim)
+    case (key: String, value: String) => Map(key -> value)
   }.fold(Map.empty)(_ ++ _)
 }
 

--- a/src/test/resources/messages.yaml
+++ b/src/test/resources/messages.yaml
@@ -1,11 +1,27 @@
 a:
   b.d: a={0} b={1} c={2}
   x: This is an example
-  f: |
-     This
-     is
-     an
-     example
+  multi-line:
+    clip: |
+          This
+          is
+          an
+          example
+    strip: |-
+           This
+           is
+           an
+           example
+
+    keep: |+
+          This
+          is
+          an
+          example
+
   e: &idA
     a: An example
   g: *idA
+spaces:
+  unquoted:  should be trimmed # comment so that IDEs don't trim the trailing space
+  quoted: " should not be trimmed "

--- a/src/test/scala/play/ext/i18n/MultiFormatMessagingPluginSpec.scala
+++ b/src/test/scala/play/ext/i18n/MultiFormatMessagingPluginSpec.scala
@@ -37,7 +37,12 @@ class MultiFormatMessagingPluginSpec extends PlaySpecification {
     }
 
     "implement advanced YAML features: multi-line strings" in {
-      messages("a.f") mustEqual "This\nis\nan\nexample"
+      // When using the vertical bar "|", the default behavior is "clipping", where the final line break is preserved.
+      // When using "|-", trailing line breaks are stripped. When using "|+", trailing line breaks are kept.
+      // https://yaml.org/spec/1.2/spec.html#id2794534
+      messages("a.multi-line.clip") mustEqual "This\nis\nan\nexample\n"
+      messages("a.multi-line.strip") mustEqual "This\nis\nan\nexample"
+      messages("a.multi-line.keep") mustEqual "This\nis\nan\nexample\n\n"
     }
 
     "implement advanced YAML features: references" in {
@@ -56,6 +61,11 @@ class MultiFormatMessagingPluginSpec extends PlaySpecification {
       // messages( "collision" ) mustEqual "Unknown result! It is non-deterministic."
       // warning log is expected
       true mustEqual true
+    }
+
+    "preserve spaces within quotes" in {
+      messages("spaces.unquoted") mustEqual "should be trimmed"
+      messages("spaces.quoted") mustEqual " should not be trimmed "
     }
   }
 }


### PR DESCRIPTION
*	Allow spaces when explicitly quoted (e.g. `" spaced "`).
*	Abide by [YAML's chomping rules with multi-line strings](https://yaml.org/spec/1.2/spec.html#id2794534).
	*	`|` preserves only the final line break ("clip").
	*	`|-` strips all trailing line breaks ("strip").
	*	`|+` preserves all trailing line breaks ("keep").

When using Play's default i18n, [it's possible to have strings with leading and trailing spaces](https://stackoverflow.com/questions/18451405/play-framework-2-i18n-use-of-space-in-conf-file), but I discovered that this plugin was trimming those spaces. This change adds that functionality, including for multi-line strings (breaking change for anyone using `|`).